### PR TITLE
hardcodeo eliminado (pendiente de sprint 1)

### DIFF
--- a/middlewares/jwtDecoder.js
+++ b/middlewares/jwtDecoder.js
@@ -3,9 +3,7 @@ function parseJwt(token) {
 }
 
 const jwtDecoder = (req, res, next) => {
-  const token = parseJwt(
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdE5hbWUiOiJNYW51ZWwiLCJsYXN0TmFtZSI6IkJhdXRpc3RhIiwiZW1haWwiOiJtYW51YmF1dGlzdGEyMDA5QGdtYWlsLmNvbSIsImlhdCI6MTY1ODE5NzA5MCwiZXhwIjoxNjU4MTk3NjkwfQ.QVTV-bPTIdgv4F4gE8VlSpFRXyYSHJreWgEd2iuSfgM"
-  );
+  const token = parseJwt(req.params.jwt);
   res.send(token);
 };
 

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -2,7 +2,8 @@ const express = require("express");
 const router = express.Router();
 const { getJWT } = require("../middlewares/jwtGenerator");
 const { jwtDecoder } = require("../middlewares/jwtDecoder");
-
+// Generar jwt
 router.get("/generate", getJWT);
-router.get("/me", jwtDecoder);
+// Enviar el jwt por URL para decodificarlo
+router.get("/me/:jwt", jwtDecoder);
 module.exports = router;


### PR DESCRIPTION
RESUMEN:
última corrección eliminando el hardcodeo que había quedado pendiente
y agregando la posibilidad de pasar el jwt generado por url auth/me/:jwt para que devuelva el jwt decodificado. 
EVIDENCIA: 
![final](https://user-images.githubusercontent.com/91494874/180349846-29ba8719-d653-4bd1-a36d-aac682002dda.png)

