### PR TITLE
Agregar campos de contacto a organizations [OT242-78]

### DIFF
--- a/migrations/20200921311532-create-organizations.js
+++ b/migrations/20200921311532-create-organizations.js
@@ -1,0 +1,52 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('organizations', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        type: Sequelize.STRING
+      },
+      image: {
+        type: Sequelize.STRING
+      },
+      phone: {
+        type: Sequelize.STRING
+      },
+      address:{
+        type: Sequelize.STRING
+      },
+      welcomeText:{
+        type: Sequelize.STRING
+      },
+      Facebook:{
+        type: Sequelize.STRING
+      },
+      Linkedin:{
+        type: Sequelize.STRING
+      },
+      Instagram:{
+        type: Sequelize.STRING
+      },
+
+      deletedAt: {
+        type: Sequelize.DATE
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('organizations');
+  }
+};


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT242/boards/332?modal=detail&selectedIssue=OT242-78&search=organi
RESUMEN:
- se agregaron las migraciones pertinentes para crear la tabla organizations ya que la misma no existía. Con los campos de redes sociales solicitados en la tarea. 

EVIDENCIA:
Resultado al correr npx sequelize-cli db:migrate
![migrate](https://user-images.githubusercontent.com/91494874/181523373-f7b0191a-1821-4eaa-9a17-8ca766f51c5a.png)
![Captura de pantalla 2022-07-28 104801](https://user-images.githubusercontent.com/91494874/181523536-d5f57622-de10-4266-88d8-7f5fae71f1c3.png)

