### PR TITLE
Modificar endpoint público de organizations para devolver links de redes sociales [OT242-79]

### DIFF
--- a/controllers/organizationControllers.js
+++ b/controllers/organizationControllers.js
@@ -1,23 +1,20 @@
-// Get the testimonials
+const { Organization } = require("../models");
+
 const getOrganizationData = async (req, res) => {
-    
-    // Petition test
-  const campos = {
-    name: 'Tomás',
-    img: "img.png",
-    phone: '3612536483',
-    address: 'san fernando 3522',
-    welcomeText: 'welcome to our organization'
+  try {
+    let query = await Organization.findAll({
+      where: { id: req.params.id },
+    });
+    if (query != '') {
+      res.status(200).json(query);
+    } else {
+      res.status(404).json({ message: "Organización inexistente." });
+    }
+  } catch (err) {
+    res.status(400).json({ message: "Ocurrió un error inesperado." });
   }
-
-
-  res.json(campos)
-
-}
-
-
+};
 
 module.exports = {
-    getOrganizationData,
-}
-
+  getOrganizationData,
+};

--- a/models/organizations.js
+++ b/models/organizations.js
@@ -1,0 +1,28 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Organization extends Model {
+    
+    static associate(models) {
+      // define association here
+    }
+  };
+  Organization.init({
+    name: DataTypes.STRING,
+    image: DataTypes.STRING,
+    phone: DataTypes.STRING,
+    address: DataTypes.STRING,
+    welcomeText: DataTypes.STRING,
+    Facebook: DataTypes.STRING,
+    Linkedin: DataTypes.STRING,
+    Instagram: DataTypes.STRING
+    
+  }, {
+    sequelize,
+    paranoid: true,
+    modelName: 'Organization'
+  });
+  return Organization;
+};

--- a/routes/organization.js
+++ b/routes/organization.js
@@ -4,7 +4,7 @@ var router = express.Router();
 const {getOrganizationData } = require('../controllers/organizationControllers')
 
 // Get the organization
-router.get('/1/public', getOrganizationData)
+router.get('/:id/public', getOrganizationData)
 
 
 


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT242/boards/332?modal=detail&selectedIssue=OT242-79
RESUMEN:
- Se modificó organizationControllers.js para que el endpoint no sea un hardcodeo sino que devuelva la información pública específica de la organización bajo el id que le pasemos por URL (params).
- Se agregó un modelo para organizations ya que no existía y no hay ninguna tarea asignada para la creación del mismo.
- Se modificó la ruta /organizations/1/public que devolvía el endpoit hardcodeado a /organizations/:id/public para que devuelva la información de la organización solicitada por params.
EVIDENCIA:
bd:
![bd](https://user-images.githubusercontent.com/91494874/181613705-2d7844ea-8f18-4cf1-bf0b-a7f3f7b399ed.png)
Solicitud de un id existente:
![ok](https://user-images.githubusercontent.com/91494874/181613733-e11ddb71-0f77-44a5-bf5d-ed1ffb7df444.png)
Solicitud de un id inexistente:
![404](https://user-images.githubusercontent.com/91494874/181613796-832bb0fc-a5f8-4295-9068-a1ccf143e754.png)

